### PR TITLE
add support for browser, include tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+dist/bitauth.browser.js
+dist/bitauth.browser.min.js

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,11 @@
+# BitAuth Browser Bundle
+
+To build a browser compatible version of BitAuth, run the following command from
+the project's root directory:
+
+```
+npm run make-dist
+```
+
+This will output `bitauth.browser.js` to this directory. The script introduces a
+global variable at `window.bitauth`.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+// get base functionality
+var bitauth = require('./lib/bitauth');
+
+// add node-specific encrypt/decrypt
+bitauth.encrypt = require('./lib/encrypt');
+bitauth.decrypt = require('./lib/decrypt');
+
+
+module.exports = bitauth;

--- a/lib/bitauth.js
+++ b/lib/bitauth.js
@@ -1,26 +1,25 @@
-var base58 = require('base58-native');
-var crypto = require('crypto');
-var bitcore = require('bitcore');
-var Key = bitcore.Key;
-var SIN = bitcore.SIN;
-var SINKey = bitcore.SINKey
-var coinUtil = bitcore.util;
+var crypto   = require('crypto');
+var bitcore  = require('bitcore');
+var Key      = bitcore.Key;
+var SIN      = bitcore.SIN;
+var SINKey   = bitcore.SINKey
+var util     = bitcore.util;
 
-var BitAuth = function() {};
+var BitAuth  = {};
 
 BitAuth.generateSin = function() {
   var sk = new SINKey();
   sk.generate();
-  var obj = sk.storeObj();
-
-  return obj;
+  return sk.storeObj();
 };
 
 BitAuth.getPublicKeyFromPrivateKey = function(privkey) {
   try {
     var key = new Key();
+
     key.private = new Buffer(privkey, 'hex');
     key.regenerateSync();
+
     return key.public.toString('hex');
   } catch (err) {
     console.log(err);
@@ -29,13 +28,13 @@ BitAuth.getPublicKeyFromPrivateKey = function(privkey) {
 };
 
 BitAuth.getSinFromPublicKey = function(pubkey) {
-  var pubkeyHash = coinUtil.sha256ripe160(new Buffer(pubkey, 'hex'));
+  var pubkeyHash = util.sha256ripe160(new Buffer(pubkey, 'hex'));
   var sin = new SIN(SIN.SIN_EPHEM, pubkeyHash);
-  return sin.toString(); 
+  return sin.toString();
 }
 
 BitAuth.sign = function(data, privkey) {
-  var hash = coinUtil.sha256(data);
+  var hash = util.sha256(data);
 
   try {
     var key = new Key();
@@ -49,7 +48,7 @@ BitAuth.sign = function(data, privkey) {
 };
 
 BitAuth.verifySignature = function(data, pubkey, signature, callback) {
-  var hash = coinUtil.sha256(data);
+  var hash = util.sha256(data);
 
   try {
     var key = new Key();
@@ -58,26 +57,6 @@ BitAuth.verifySignature = function(data, pubkey, signature, callback) {
   } catch (err) {
     callback(err, false);
   }
-};
-
-BitAuth.encrypt = function(password, str) {
-  var aes256 = crypto.createCipher('aes-256-cbc', password);
-  var a = aes256.update(str, 'utf8');
-  var b = aes256.final();
-  var buf = new Buffer(a.length + b.length);
-  a.copy(buf, 0);
-  b.copy(buf, a.length);
-  return base58.encode(buf);
-};
-
-BitAuth.decrypt = function(password, str) {
-  var aes256 = crypto.createDecipher('aes-256-cbc', password);
-  var a = aes256.update(base58.decode(str));
-  var b = aes256.final();
-  var buf = new Buffer(a.length + b.length);
-  a.copy(buf, 0);
-  b.copy(buf, a.length);
-  return buf.toString('utf8');
 };
 
 module.exports = BitAuth;

--- a/lib/decrypt.js
+++ b/lib/decrypt.js
@@ -1,0 +1,14 @@
+var base58 = require('base58-native');
+var crypto = require('crypto');
+
+module.exports = function decrypt(password, str) {
+  var aes256 = crypto.createDecipher('aes-256-cbc', password);
+  var a      = aes256.update(base58.decode(str));
+  var b      = aes256.final();
+  var buf    = new Buffer(a.length + b.length);
+
+  a.copy(buf, 0);
+  b.copy(buf, a.length);
+
+  return buf.toString('utf8');
+};

--- a/lib/encrypt.js
+++ b/lib/encrypt.js
@@ -1,0 +1,14 @@
+var base58 = require('base58-native');
+var crypto = require('crypto');
+
+module.exports = function encrypt(password, str) {
+  var aes256 = crypto.createCipher('aes-256-cbc', password);
+  var a      = aes256.update(str, 'utf8');
+  var b      = aes256.final();
+  var buf    = new Buffer(a.length + b.length);
+
+  a.copy(buf, 0);
+  b.copy(buf, a.length);
+  
+  return base58.encode(buf);
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "make-dist": "sh scripts/make-dist.sh",
+    "test": "node_modules/.bin/mocha test/* --reporter spec",
     "postinstall": "npm run make-dist"
   },
   "main": "index.js",
@@ -26,6 +27,8 @@
   },
   "devDependencies": {
     "uglify-js": "~2.4.14",
-    "browserify": "~4.1.11"
+    "browserify": "~4.1.11",
+    "should": "~4.0.4",
+    "mocha": "~1.20.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,27 @@
     "name": "Patrick Nagurny",
     "email": "patrick@bitpay.com"
   },
-  "version": "0.1.0",
+  "contributors": [
+    {
+      "name": "Gordon Hall",
+      "email": "gordon@bitpay.com"
+    }
+  ],
+  "scripts": {
+    "make-dist": "sh scripts/make-dist.sh",
+    "postinstall": "npm run make-dist"
+  },
+  "main": "index.js",
+  "version": "0.1.1",
   "dependencies": {
     "bitcore": ">= 0.1.9",
     "request": "^2.36.0",
     "express": "^4.3.1",
     "base58-native": "^0.1.4",
     "body-parser": "^1.2.0"
+  },
+  "devDependencies": {
+    "uglify-js": "~2.4.14",
+    "browserify": "~4.1.11"
   }
 }

--- a/scripts/make-dist.sh
+++ b/scripts/make-dist.sh
@@ -1,0 +1,11 @@
+cd node_modules/bitcore
+echo "Building browser bundle for bitcore..."
+node browser/build -s lib/Key,lib/SINKey,lib/SIN,util/util
+echo "Building browser bundle for bitauth..."
+cd ../../
+node_modules/.bin/browserify lib/bitauth.js -s bitauth -x buffertools -i bitcore -o dist/bitauth.browser.js
+echo "Compiling bitcore and bitauth..."
+node_modules/.bin/uglifyjs node_modules/bitcore/browser/bundle.js dist/bitauth.browser.js -b -o dist/bitauth.browser.js
+echo "Minifying bundle..."
+node_modules/.bin/uglifyjs dist/bitauth.browser.js -o dist/bitauth.browser.min.js
+echo "Done!"

--- a/test/bitauth.js
+++ b/test/bitauth.js
@@ -1,0 +1,82 @@
+var should  = require('should');
+var bitauth = require('../index');
+
+describe('bitauth', function() {
+
+  var keys      = null;
+  var contract  = 'keyboard cat';
+  var secret    = 'o hai, nsa. how i do teh cryptos?';
+  var password  = 's4705hiru13z!';
+  var signature = null;
+  var enc       = null;
+
+  describe('#generateSin', function() {
+
+    it('should generate a sin object', function(done) {
+      keys = bitauth.generateSin();
+      should.exist(keys);
+      should.exist(keys.pub);
+      should.exist(keys.priv);
+      should.exist(keys.sin);
+      done();
+    });
+
+  });
+
+  describe('#getPublicKeyFromPrivateKey', function() {
+
+    it('should properly get the public key', function(done) {
+      bitauth.getPublicKeyFromPrivateKey(keys.priv).should.equal(keys.pub);
+      done();
+    });
+
+  });
+
+  describe('#getSinFromPublicKey', function() {
+
+    it('should properly get the sin', function(done) {
+      bitauth.getSinFromPublicKey(keys.pub).should.equal(keys.sin);
+      done();
+    });
+
+  });
+
+  describe('#sign', function() {
+
+    it('should sign the string', function(done) {
+      signature = bitauth.sign(contract, keys.priv);
+      should.exist(signature);
+      done();
+    });
+
+  });
+
+  describe('#verifySignature', function() {
+
+    it('should verify the signature', function(done) {
+      bitauth.verifySignature(contract, keys.pub, signature, done);
+    });
+
+  });
+
+  describe('#encrypt', function() {
+
+    it('should encrypt the secret message', function(done) {
+      enc = bitauth.encrypt(password, secret);
+      should.exist(enc);
+      done();
+    });
+
+  });
+
+  describe('#decrypt', function() {
+
+    it('should decrypt the secret message', function(done) {
+      var dec = bitauth.decrypt(password, enc);
+      should.exist(dec);
+      done();
+    });
+
+  });
+
+});


### PR DESCRIPTION
- generate a browser bundle with `npm run make-dist` (happens automatically upon postinstall)
- adds tests for the `bitauth` module (run with `npm test`)
- moves `encrypt()` and `decrypt()` outside of the core bitauth object, so it can be more easily browserified
- some minor nit-picky convention/semantic changes
- add self to package.json contributors
