### PR TITLE
Fix typo with utf-8 -> utf8

### DIFF
--- a/lib/bitauth-common.js
+++ b/lib/bitauth-common.js
@@ -85,7 +85,7 @@ BitAuth.getSinFromPublicKey = function(pubkey) {
 BitAuth.sign = function(data, privkey) {
   var dataBuffer;
   if (!Buffer.isBuffer(data)) {
-    dataBuffer = new Buffer(data, 'utf-8');
+    dataBuffer = new Buffer(data, 'utf8');
   } else {
     dataBuffer = data;
   }
@@ -105,7 +105,7 @@ BitAuth.sign = function(data, privkey) {
 BitAuth.verifySignature = function(data, pubkey, hexsignature, callback) {
   var dataBuffer;
   if (!Buffer.isBuffer(data)) {
-    dataBuffer = new Buffer(data, 'utf-8');
+    dataBuffer = new Buffer(data, 'utf8');
   } else {
     dataBuffer = data;
   }


### PR DESCRIPTION
The default encoding is utf8, and hence specifying utf-8 would achieve the same result.
https://nodejs.org/api/buffer.html#buffer_buffer
https://nodejs.org/docs/latest-v0.12.x/api/buffer.html#buffer_buffer
https://nodejs.org/docs/latest-v0.10.x/api/buffer.html#buffer_buffer
