### PR TITLE
Fix comment: pubkey => pubHash

### DIFF
--- a/lib/bitauth-common.js
+++ b/lib/bitauth-common.js
@@ -52,7 +52,7 @@ BitAuth.getSinFromPublicKey = function(pubkey) {
   // sha256 hash the pubkey
   var pubHash = crypto.createHash('sha256').update(pubkeyBuffer).digest();
 
-  // get the ripemd160 hash of the pubkey
+  // get the ripemd160 hash of the pubHash
   var pubRipe = crypto.createHash('rmd160').update(pubHash).digest();
 
   // add the version


### PR DESCRIPTION
Minor comment fix.

```javascript
  // get the ripemd160 hash of the pubkey
  var pubRipe = crypto.createHash('rmd160').update(pubHash).digest();
```

Thw comment is technically not correct. So I fixed it to be:

```javascript
  // get the ripemd160 hash of the pubHash
  var pubRipe = crypto.createHash('rmd160').update(pubHash).digest();
```