### PR TITLE
[UPDATE] secp256k1 to version 4.0.2

### DIFF
--- a/lib/bitauth-node.js
+++ b/lib/bitauth-node.js
@@ -6,7 +6,7 @@ const crypto = require('crypto');
 
 BitAuth._generateRandomPair = function() {
   const privateKeyBuffer = crypto.randomBytes(32); // may throw error if entropy sources drained
-  const publicKeyBuffer = secp256k1.publicKeyCreate(privateKeyBuffer, true);
+  const publicKeyBuffer = Buffer.from(secp256k1.publicKeyCreate(privateKeyBuffer, true));
   return [privateKeyBuffer.toString('hex'), publicKeyBuffer.toString('hex')];
 };
 
@@ -17,7 +17,7 @@ BitAuth._getPublicKeyFromPrivateKey = function(privkey) {
   } else {
     privateKeyBuffer = Buffer.from(privkey, 'hex');
   }
-  return secp256k1.publicKeyCreate(privateKeyBuffer, true);
+  return Buffer.from(secp256k1.publicKeyCreate(privateKeyBuffer, true));
 };
 
 BitAuth._sign = function(hashBuffer, privkey) {
@@ -27,19 +27,19 @@ BitAuth._sign = function(hashBuffer, privkey) {
   } else {
     privkeyBuffer = Buffer.from(privkey, 'hex');
   }
-  var signatureInfo = secp256k1.sign(hashBuffer, privkeyBuffer);
-  return secp256k1.signatureExport(signatureInfo.signature);
+  var signatureInfo = secp256k1.ecdsaSign(hashBuffer, privkeyBuffer);
+  return Buffer.from(secp256k1.signatureExport(signatureInfo.signature));
 };
 
 BitAuth._verifySignature = function(hashBuffer, signatureBuffer, pubkey) {
   let pubkeyBuffer;
-  const signature = secp256k1.signatureNormalize(secp256k1.signatureImportLax(signatureBuffer));
+  const signature = secp256k1.signatureNormalize(secp256k1.signatureImport(signatureBuffer));
   if (!Buffer.isBuffer(pubkey)){
     pubkeyBuffer = Buffer.from(pubkey, 'hex');
   } else {
     pubkeyBuffer = pubkey;
   }
-  return !!secp256k1.verify(hashBuffer, signature, pubkeyBuffer);
+  return !!secp256k1.ecdsaVerify(signature, hashBuffer, pubkeyBuffer);
 };
 
 module.exports = BitAuth;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "version": "0.4.0",
   "dependencies": {
     "bs58": "^2.0.0",
-    "secp256k1": "3.7.1"
+    "secp256k1": "4.0.2"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",


### PR DESCRIPTION
v3: https://github.com/cryptocoinjs/secp256k1-node/blob/v3.x/API.md
v4 : https://github.com/cryptocoinjs/secp256k1-node/blob/master/API.md